### PR TITLE
feat: templates for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This command will not overwrite existing content unless you say so.
 npx migrations content --source-env <environment>  --dest-env <environment>
 ```
 
-##### Optional Arguments
+#### Optional arguments
 
 `--content-type`: Limit to specific content-type and it's dependencies.<br/>
 `--diff`: Manually choose skip/overwrite for every conflicting content.<br/>
@@ -86,6 +86,10 @@ Generate simple markdown docs for the content-types
 ```bash
 npx migrations doc -e <environment> -p <path/to/docs>
 ```
+
+#### Optional arguments
+
+`--template`: Choose between the **api** (default) and the more compact **editor** markdown template
 
 ## Can I contribute?
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const parseArgs = (cmd) => {
     directory: directory ? path.resolve(directory) : undefined,
     sourceEnvironment: cmd.sourceEnv || parent.sourceEnv,
     destEnvironment: cmd.destEnv || parent.destEnv,
+    template: cmd.template || parent.template,
     verbose: cmd.verbose || parent.verbose,
   };
 };
@@ -113,6 +114,7 @@ program
   .command('doc')
   .option('-e, --env <environment>', 'Change the contentful environment')
   .option('-p, --path <path/to/docs>', 'Change the path where the docs are stored')
+  .option('-t, --template <template>', 'Change the docs template')
   .option('-v, --verbose', 'Verbosity')
   .description('Generate offline docs from content-types')
   .action(

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ const getConfig = async (args) => {
     fallbackEnvironment: 'master',
     host: 'api.contentful.com',
     directory: path.resolve(process.cwd(), 'migrations'),
+    template: 'api',
   };
 
   const environmentOptions = {
@@ -130,6 +131,14 @@ const getPromts = (data) => {
       message: 'Directory where the migrations are stored',
       default: function () {
         return data.directory;
+      },
+    },
+    {
+      type: 'input',
+      name: 'template',
+      message: 'Markdown template used for documentation files',
+      default: function () {
+        return data.template;
       },
     },
   ];

--- a/lib/doc.js
+++ b/lib/doc.js
@@ -1,80 +1,33 @@
 const path = require('path');
-const table = require('markdown-table');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const { getEditorInterfaces, getContentTypes, getContentTypeId, getContentId } = require('./contentful');
-
-const getFieldTable = (fields, editorInterfaces) => {
-  const { controls = [] } = editorInterfaces;
-  return table([
-    ['Id', 'Name', 'Type', 'Required', 'Localized', 'HelpText', 'Remarks'],
-    ...fields.map((field) => {
-      const { id, name, type, localized, required, items } = field;
-      const { settings } = controls.find(({ fieldId }) => fieldId === id) || {};
-      const { linkType } = items || {};
-      const { helpText = '' } = settings || {};
-      return [
-        id,
-        name,
-        linkType ? `${type}<${linkType}>` : type,
-        required ? '✓' : '✗',
-        localized ? '✓' : '✗',
-        helpText,
-        '',
-      ];
-    }),
-  ]);
-};
-
-const createDoc = (contentType, editorInterfaces) => {
-  const { name, displayField, description, sys, fields } = contentType || {};
-  const { id } = sys || {};
-
-  return `
-${name}
--------
-
-## Common Properties
-
-${table([
-  ['Property', 'Value'],
-  ['**Name:**', name],
-  ['**ID:**', id],
-  ['**DisplayField:**', displayField],
-])}
-
-## Description
-
-${description}
-
-## Fields
-
-${getFieldTable(fields, editorInterfaces)}
-`;
-};
+const { createApiDoc } = require('./templates/api');
+const { createEditorDoc } = require('./templates/editor');
 
 /**
- * Create new migration file.
- * Adds initial migration file adding the migration field in the content type
+ * Create offline docs
  * @param {Object} config The config object including all required data
  */
 const createOfflineDocs = async (config) => {
   console.log('Generating offline docs for content-types ...\n');
-  const { directory } = config || {};
+  const { directory, template } = config || {};
   const contentTypes = await getContentTypes(config);
   const editorInterfaces = await getEditorInterfaces(config);
 
   for (let contentType of contentTypes) {
     const interfaces = editorInterfaces.find((node) => getContentTypeId(node) === getContentId(contentType));
-    const content = createDoc(contentType, interfaces);
+    let content = '';
+    if (template === 'editor') {
+      content = createEditorDoc(contentType, interfaces);
+    } else {
+      content = createApiDoc(contentType, interfaces);
+    }
     const filename = `${getContentId(contentType)}.md`;
     const filepath = path.join(directory, filename);
     await fs.outputFile(filepath, content);
     console.log(` - ${chalk.green(path.relative(process.cwd(), filepath))}`);
   }
-
-  // await fs.outputFile(filename, content);
-  // console.log(`Generated new migration file to ${chalk.green(filename)}`);
 };
 
 module.exports.createOfflineDocs = createOfflineDocs;

--- a/lib/templates/api.js
+++ b/lib/templates/api.js
@@ -1,0 +1,52 @@
+const table = require('markdown-table');
+
+const getFieldTable = (fields, editorInterfaces) => {
+  const { controls = [] } = editorInterfaces;
+  return table([
+    ['Id', 'Name', 'Type', 'Required', 'Localized', 'HelpText', 'Remarks'],
+    ...fields.map((field) => {
+      const { id, name, type, localized, required, items } = field;
+      const { settings } = controls.find(({ fieldId }) => fieldId === id) || {};
+      const { linkType } = items || {};
+      const { helpText = '' } = settings || {};
+      return [
+        id,
+        name,
+        linkType ? `${type}<${linkType}>` : type,
+        required ? '✓' : '✗',
+        localized ? '✓' : '✗',
+        helpText,
+        '',
+      ];
+    }),
+  ]);
+};
+
+const createApiDoc = (contentType, editorInterfaces) => {
+  const { name, displayField, description, sys, fields } = contentType || {};
+  const { id } = sys || {};
+
+return `
+${name}
+-------
+
+## Common Properties
+
+${table([
+  ['Property', 'Value'],
+  ['**Name:**', name],
+  ['**ID:**', id],
+  ['**DisplayField:**', displayField],
+])}
+
+## Description
+
+${description}
+
+## Fields
+
+${getFieldTable(fields, editorInterfaces)}
+`;
+};
+
+module.exports.createApiDoc = createApiDoc;

--- a/lib/templates/editor.js
+++ b/lib/templates/editor.js
@@ -1,0 +1,29 @@
+const table = require('markdown-table');
+
+const formatValidations = (validations) => {
+  let formattedValidation = '';
+  for (const validation of validations) {
+    formattedValidation = formattedValidation + `\`${JSON.stringify(validation).replace(/\|/g, '&#124;')}\`. `;
+  }
+  return formattedValidation;
+};
+
+const getFieldTable = (fields, editorInterfaces) => {
+  const { controls = [] } = editorInterfaces;
+  return table([
+    ['Name', 'ID', 'Type', 'Required', 'Validations', 'Help text'],
+    ...fields.map((field) => {
+      const { id, name, type, validations, required } = field;
+      const { settings } = controls.find(({ fieldId }) => fieldId === id) || {};
+      const { helpText = '' } = settings || {};
+      return [name, id, type, required ? '✓' : '', formatValidations(validations), helpText];
+    }),
+  ]);
+};
+
+const createEditorDoc = (contentType, editorInterfaces) => {
+  const { fields } = contentType || {};
+  return getFieldTable(fields, editorInterfaces);
+};
+
+module.exports.createEditorDoc = createEditorDoc;

--- a/package-lock.json
+++ b/package-lock.json
@@ -243,6 +243,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -274,6 +287,24 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -288,11 +319,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-    },
-    "@types/repeat-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@types/repeat-string/-/repeat-string-1.6.0.tgz",
-      "integrity": "sha512-Nwr4xMZBJKzluvdF9QPKjqFi8EpR63jk0mQPBEXB/+kevUPBftRQrbt24m+NkRh0C9ftrNIqnnsDw9iyQv/j7g=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1730,27 +1756,59 @@
       }
     },
     "contentful-migration": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.1.17.tgz",
-      "integrity": "sha512-+OfW+oeRIxTMKfxuAt+TE0HpGP8pVUExW3fucUCOcFNtQxkEMQygY1wmEutLNaDAobUQBqfPdqakOmVFRdKGcg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.2.5.tgz",
+      "integrity": "sha512-3aTt/XAHrlVDJ254o164Qoyr+FNrtK5nLbHdQ1T94Jtw7kRnfL91jDUk+UpkLQT/pdjkoAXx9PFHJSYU148XHA==",
       "requires": {
         "axios": "^0.21.0",
         "bluebird": "^3.7.2",
         "callsites": "^3.1.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.0.0",
-        "contentful-management": "^7.3.1",
-        "didyoumean2": "^4.0.0",
+        "contentful-management": "^7.25.1",
+        "didyoumean2": "^5.0.0",
         "hoek": "^6.1.3",
         "https-proxy-agent": "^5.0.0",
         "inquirer": "^7.1.0",
-        "joi": "^10.6.0",
+        "joi": "^17.4.0",
         "kind-of": "^6.0.3",
         "listr": "^0.14.3",
         "lodash": "^4.17.15",
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "contentful-management": {
+          "version": "7.31.0",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.31.0.tgz",
+          "integrity": "sha512-YhPikvkO/ckRTO400I+iHYpVLuHwPyMzTQcMwBWpUluXYCF45I/RpWw7cyNQciQ19Q0NpjgEfUTQnhFhIqHtwA==",
+          "requires": {
+            "@types/json-patch": "0.0.30",
+            "axios": "^0.21.0",
+            "contentful-sdk-core": "^6.8.0",
+            "fast-copy": "^2.1.0",
+            "lodash.isplainobject": "^4.0.6",
+            "type-fest": "^0.20.2"
+          }
+        },
+        "contentful-sdk-core": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.8.0.tgz",
+          "integrity": "sha512-X45uNrcbQ2qY2p4G/Wx2EFUdnLnoDXjw29i+d0JVTUXqCG58p3q4GHuAPzTX+uafJL4h0ZY2xPOn4nvJ83eRBQ==",
+          "requires": {
+            "fast-copy": "^2.1.0",
+            "qs": "^6.9.4"
+          }
+        },
+        "didyoumean2": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-5.0.0.tgz",
+          "integrity": "sha512-Plha9WCF08aSGB39IsOhlk0AHecwcXtq/gMbHgylRNEv7JV3lnlt7akfdax7mnUHndEuuh57CmBaKSSXns7+YA==",
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "fastest-levenshtein": "^1.0.12",
+            "lodash.deburr": "^4.1.0"
+          }
+        },
         "hoek": {
           "version": "6.1.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
@@ -1776,27 +1834,16 @@
             "through": "^2.3.6"
           }
         },
-        "isemail": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-        },
         "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "version": "17.4.2",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+          "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
           "requires": {
-            "hoek": "4.x.x",
-            "isemail": "2.x.x",
-            "items": "2.x.x",
-            "topo": "2.x.x"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-            }
+            "@hapi/hoek": "^9.0.0",
+            "@hapi/topo": "^5.0.0",
+            "@sideway/address": "^4.1.0",
+            "@sideway/formula": "^3.0.0",
+            "@sideway/pinpoint": "^2.0.0"
           }
         },
         "rxjs": {
@@ -1807,20 +1854,10 @@
             "tslib": "^1.9.0"
           }
         },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "requires": {
-            "hoek": "4.x.x"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-            }
-          }
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         },
         "yargs": {
           "version": "15.4.1",
@@ -2708,6 +2745,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
       "version": "1.11.0",
@@ -4603,11 +4645,10 @@
       }
     },
     "markdown-table": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.0.tgz",
-      "integrity": "sha512-sSFatFzGRPVHCKgj80iNcYDdySAGS36qBzPON99RO0Zl5YwkK38zmhMQ0QSJik3YxGroyBnqP51ZGLueDtOqmg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
       "requires": {
-        "@types/repeat-string": "^1.0.0",
         "repeat-string": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "git-branch": "^2.0.1",
     "globby": "^11.0.3",
     "inquirer": "^8.1.0",
-    "markdown-table": "^3.0.0",
+    "markdown-table": "^2.0.0",
     "merge-options": "^3.0.4",
     "node-fetch": "^2.6.1",
     "pkg-up": "^3.1.0"


### PR DESCRIPTION
This pr introduces the option to choose between templates for docs.

- You can choose between the `api` (default)  and the new `editor` markdown template
- The `api` template uses the current state of markdown output 
- The `editor` template is more compact and also shows the validation data
- TBD: I need to downgrade the markdown-table package, because it is ESM only

## Examples

### api template
<img width="916" alt="api-template" src="https://user-images.githubusercontent.com/3438532/129032021-c659c607-6cbc-4041-a51d-46f9f9433a56.png">

### editor template
<img width="938" alt="editor-template" src="https://user-images.githubusercontent.com/3438532/129032048-f61b23b6-9c52-4ea8-a1c8-a57bf9ed47e7.png">

## Todo

In the next step, the validation data could be formatted more/better.

For example:
**Values:** `white`, `faded-gray`

...instead of:
`{"in":["white","faded-gray"]}`
