### PR TITLE
Fix undefined assetOverwrites variable

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -133,7 +133,7 @@ const transferContent = async (config) => {
   });
 
   // just a small helper to add a line break after the inquiry
-  const br = diffConflicts && (Object.keys(assetOverwrites).length || Object.keys(entryOverwrites).length) ? '\n' : '';
+  const br = diffConflicts && Object.keys(entryOverwrites).length ? '\n' : '';
 
   if (assets.length === 0 && entries.length === 0) {
     console.log(chalk.green(`${br}All done`), '🚀');


### PR DESCRIPTION
Closes #48.

The assumption about the usage of `assetOvewrites` might be incorrect. Please correct the pull request if this variable is expected to be defined at this point.