### PR TITLE
Fix small typo in config prompt

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -111,7 +111,7 @@ const getPromts = (data) => {
     {
       type: 'list',
       name: 'storage',
-      message: 'How do should the migrations be managed',
+      message: 'How should the migrations be managed',
       choices: [
         {
           name: 'Content-model (recommended)',


### PR DESCRIPTION
The `do` in the sentence is grammatically incorrect.