### PR TITLE
Remove undefined variable `entryOverwrites`

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -133,7 +133,7 @@ const transferContent = async (config) => {
   });
 
   // just a small helper to add a line break after the inquiry
-  const br = diffConflicts && Object.keys(entryOverwrites).length ? '\n' : '';
+  const br = diffConflicts ? '\n' : '';
 
   if (assets.length === 0 && entries.length === 0) {
     console.log(chalk.green(`${br}All done`), '🚀');


### PR DESCRIPTION
When running the following command:

```
npx migrations content --source-environment-id master--dest-environment-id non-master --verbose --diff
```

And going through the process to resolve conflicts, the following error appears and aborts the whole process:

```
Error: entryOverwrites is not defined
```

This PR solves this problem by removing the reference to this undefined variable.