### PR TITLE
Feature: Richtext validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,42 @@ module.exports = withHelpers(async (migration, context, helpers) => {
 
   // Add or remove values from "in" validations without knowing all the other elements in the array
   await helpers.validation.addInValues('contentTypeId', 'fieldId', ['value']); // add at the end
-  await helpers.validation.addInValues('contentTypeId', 'fieldId', ['value'], { mode: 'sorted'}); // add and sort
+  await helpers.validation.addInValues('contentTypeId', 'fieldId', ['value'], { mode: 'sorted' }); // add and sort
   await helpers.validation.removeInValues('contentTypeId', 'fieldId', ['value']);
   await helpers.validation.modifyInValues('contentTypeId', 'fieldId', (existing) => {
     const result = existing.filter((value) => value.startsWith('prefix')); // keep values with prefix
     result.push('other'); // and add one
+    return result; // possible duplicate values are removed afterwards
+  });
+
+  // Add or remove enabled marks for a rich text field without knowing all the active marks
+  // See: https://github.com/contentful/rich-text/blob/master/packages/rich-text-types/src/marks.ts
+  await helpers.validation.richText.addEnabledMarksValues('contentTypeId', 'fieldId', ['bold']);
+  await helpers.validation.richText.removeEnabledMarksValues('contentTypeId', 'fieldId', ['underline']); // add at the end
+  await helpers.validation.richText.modifyEnabledMarksValues('contentTypeId', 'fieldId', (existing) => {
+    const result = existing.filter((value) => value !== 'code'); // keep values with prefix
+    result.push('italic'); // and add one
+    return result; // possible duplicate values are removed afterwards
+  });
+
+  // Add or remove enabled node types for a rich text field without knowing all the active node types
+  // See https://github.com/contentful/rich-text/blob/master/packages/rich-text-types/src/blocks.ts
+  // and https://github.com/contentful/rich-text/blob/master/packages/rich-text-types/src/inlines.ts
+  await helpers.validation.richText.addEnabledNodeTypeValues('contentTypeId', 'fieldId', ['blockquote']);
+  await helpers.validation.richText.removeEnabledNodeTypeValues('contentTypeId', 'fieldId', ['hyperlink']); // add at the end
+  await helpers.validation.richText.modifyEnabledNodeTypeValues('contentTypeId', 'fieldId', (existing) => {
+    const result = existing.filter((value) => !value.startsWith('heading-')); // filter out headings like 'heading-1'
+    result.push('quote'); // and add one
+    return result; // possible duplicate values are removed afterwards
+  });
+
+  // Add or remove embedded ot linked content types for a rich text field without knowing all the allowed content types
+  // The possible node types are 'entry-hyperlink', 'embedded-entry-block' and 'embedded-entry-inline'.
+  await helpers.validation.richText.addNodeContentTypeValues('contentTypeId', 'fieldId', ['blockquote']);
+  await helpers.validation.richText.removeNodeContentTypeValues('contentTypeId', 'fieldId', ['hyperlink']); // add at the end
+  await helpers.validation.richText.modifyNodeContentTypeValues('contentTypeId', 'fieldId', (existing) => {
+    const result = existing.filter((value) => !value.startsWith('heading-')); // filter out headings like 'heading-1'
+    result.push('quote'); // and add one
     return result; // possible duplicate values are removed afterwards
   });
 
@@ -226,7 +257,7 @@ free to open up an issue and we can discuss it.
 
 ## Contributors
 <a href="https://github.com/jungvonmatt/contentful-migrations/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=jungvonmatt/contentful-migrations" />
+  <img alt="Contributor profile pictures" src="https://contrib.rocks/image?repo=jungvonmatt/contentful-migrations" />
 </a>
 
 [npm-url]: https://www.npmjs.com/package/@jungvonmatt/contentful-migrations

--- a/lib/helpers/validation.d.ts
+++ b/lib/helpers/validation.d.ts
@@ -10,13 +10,33 @@ export interface AddValuesOptions {
   ref?: string;
 }
 
+export type RichTextMarks = 'bold' | 'italic' | 'underline' | 'code';
+export type RichTextLinkedNodeType = 'entry-hyperlink' | 'embedded-entry-block' | 'embedded-entry-inline'
+
+export interface RichTextValidationHelpers {
+  addEnabledMarksValue(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
+  removeEnabledMarksValue(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
+  modifyEnabledMarksValue(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+
+  addEnabledNodeTypeValue(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
+  removeEnabledNodeTypeValue(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
+  modifyEnabledNodeTypeValue(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+
+  addNodeContentTypeValues(contentTypeId: string, fieldId: string, nodeType: RichTextLinkedNodeType, values: string | string[]): Promise<void>;
+  removeNodeContentTypeValues(contentTypeId: string, fieldId: string, nodeType: RichTextLinkedNodeType, values: string | string[]): Promise<void>;
+  modifyNodeContentTypeValues(contentTypeId: string, fieldId: string, nodeType: RichTextLinkedNodeType, valueMappingFunction: ValueMappingFunction): Promise<void>;
+}
+
 export interface ValidationHelpers {
   addLinkContentTypeValues(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
-  addInValues(contentTypeId: string, fieldId: string, values: string | string[], options?: AddValuesOptions): Promise<void>;
   removeLinkContentTypeValues(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
-  removeInValues(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
   modifyLinkContentTypeValues(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+
+  addInValues(contentTypeId: string, fieldId: string, values: string | string[], options?: AddValuesOptions): Promise<void>;
+  removeInValues(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
   modifyInValues(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+
+  richText: RichTextValidationHelpers;
 }
 
 export function getValidationHelpers(migration: Migration, context: MigrationContext): ValidationHelpers;

--- a/lib/helpers/validation.d.ts
+++ b/lib/helpers/validation.d.ts
@@ -1,7 +1,7 @@
 import type Migration from "contentful-migration";
 import type { MigrationContext } from "contentful-migration";
 
-export type ValueMappingFunction = (values: string[]) => string[];
+export type ValueMappingFunction<T extends string = string> = (values: T[]) => T[];
 
 export type AddValuesOptionMode = 'sorted' | 'start' | 'end' | 'before' | 'after';
 
@@ -10,17 +10,20 @@ export interface AddValuesOptions {
   ref?: string;
 }
 
-export type RichTextMarks = 'bold' | 'italic' | 'underline' | 'code';
+// define some known mark and node values here to support code completion, but allow any string as well
+export type RichTextMarks = 'bold' | 'italic' | 'underline' | 'code' | 'superscript' | 'subscript' | 'strikethrough' | string & {};
+export type RichTextNodeType = 'document' | 'paragraph' | 'heading-1' | 'heading-2' | 'heading-3' | 'heading-4' | 'heading-5' | 'heading-6' | 'ordered-list' | 'unordered-list' | 'list-item' | 'hr' | 'blockquote' | 'embedded-entry-block' | 'embedded-asset-block' | 'embedded-resource-block' | 'table' | 'table-row' | 'table-cell' | 'table-header-cell' | 'asset-hyperlink' | 'embedded-entry-inline' | 'embedded-resource-inline' | 'entry-hyperlink' | 'hyperlink' | 'resource-hyperlink' | string & {};
+
 export type RichTextLinkedNodeType = 'entry-hyperlink' | 'embedded-entry-block' | 'embedded-entry-inline'
 
 export interface RichTextValidationHelpers {
-  addEnabledMarksValue(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
-  removeEnabledMarksValue(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
-  modifyEnabledMarksValue(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+  addEnabledMarksValues(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
+  removeEnabledMarksValues(contentTypeId: string, fieldId: string, values: RichTextMarks | RichTextMarks[]): Promise<void>;
+  modifyEnabledMarksValues(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction<RichTextMarks>): Promise<void>;
 
-  addEnabledNodeTypeValue(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
-  removeEnabledNodeTypeValue(contentTypeId: string, fieldId: string, values: string | string[]): Promise<void>;
-  modifyEnabledNodeTypeValue(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction): Promise<void>;
+  addEnabledNodeTypeValues(contentTypeId: string, fieldId: string, values: RichTextNodeType | RichTextNodeType[]): Promise<void>;
+  removeEnabledNodeTypeValues(contentTypeId: string, fieldId: string, values: RichTextNodeType | RichTextNodeType[]): Promise<void>;
+  modifyEnabledNodeTypeValues(contentTypeId: string, fieldId: string, valueMappingFunction: ValueMappingFunction<RichTextNodeType>): Promise<void>;
 
   addNodeContentTypeValues(contentTypeId: string, fieldId: string, nodeType: RichTextLinkedNodeType, values: string | string[]): Promise<void>;
   removeNodeContentTypeValues(contentTypeId: string, fieldId: string, nodeType: RichTextLinkedNodeType, values: string | string[]): Promise<void>;

--- a/lib/helpers/validation.js
+++ b/lib/helpers/validation.js
@@ -27,26 +27,59 @@ const getValidationHelpers = (migration, context) => {
   const removeValidationValues = (existingValues, newValues = []) =>
     existingValues.filter((x) => !newValues.includes(x));
 
-  const modifyValidations = (validations, method, key, values) =>
-    validations.map((validation) => {
-      if (validation?.[key]) {
-        if (!Array.isArray(values)) {
-          values = [values];
+  /**
+   * Ensure the complete key path is available.
+   * If more than two keys are given the first node is treated as an Object.
+   * Return the container node, which should be an array.
+   * @param root {Object} The root container (the validations array)
+   * @param keyPath {string[]} The names of the nodes that must exist
+   * @return {Array} A tupel with the container object and the last key.
+   */
+  const ensureObjectPath = (root, keyPath) => {
+    let container = undefined;
+    let node = root;
+    keyPath.forEach((key, index) => {
+      container = node;
+      const isObjectNode = keyPath.length > 2 && index === 0;
+      if (Array.isArray(node)) {
+        let entry = node.find((someEntry) => someEntry[key]);
+        if (!entry) {
+          entry = { [key]: isObjectNode ? {} : [] };
+          node.push(entry);
         }
-        if (!Array.isArray(validation[key])) {
-          throw new Error(
-            `modifying validation properties is only supported on arrays. validation.${key} is typeof ${typeof validation[
-              key
-            ]}`
-          );
+        container = entry;
+        node = entry[key];
+      } else {
+        if (!node[key]) {
+          node[key] = isObjectNode ? {} : [];
         }
-        validation[key] = method(validation[key], values);
+        node = node[key];
       }
-
-      return validation;
     });
+    return [container, keyPath[keyPath.length - 1]];
+  };
 
-  const modifyValidationValuesForType = async (validationKey, method, contentTypeId, fieldId, values) => {
+  /**
+   * Modify a validation property.
+   * @param validations The list of validation entries
+   * @param {function} method The modification function
+   * @param {string[]} keyPaths The key paths where the first is the id of the validation root.
+   * @param {string | string[]} values
+   * @returns {*}
+   */
+  const modifyValidations = (validations = [], method, keyPaths, values) => {
+    const [containerObject, validationKey] = ensureObjectPath(validations, keyPaths);
+
+    const resultList = method(containerObject[validationKey], values);
+
+    containerObject[validationKey] = resultList;
+
+    return validations;
+  };
+
+  const modifyValidationValuesForType = async (validationKeyPaths, method, contentTypeId, fieldId, valueOrValues) => {
+    const values = Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues];
+
     // Fetch content type
     const { fields } = await makeRequest({
       method: 'GET',
@@ -62,11 +95,11 @@ const getValidationHelpers = (migration, context) => {
       const ct = migration.editContentType(contentTypeId);
       ct.editField(fieldId).items({
         ...items,
-        validations: modifyValidations(items?.validations, method, validationKey, values),
+        validations: modifyValidations(items?.validations, method, validationKeyPaths, values),
       });
     } else {
       const ct = migration.editContentType(contentTypeId);
-      ct.editField(fieldId).validations(modifyValidations(validations, method, validationKey, values));
+      ct.editField(fieldId).validations(modifyValidations(validations, method, validationKeyPaths, values));
     }
   };
 
@@ -75,7 +108,7 @@ const getValidationHelpers = (migration, context) => {
      * Add the specified values to the list of allowed content type values
      */
     async addLinkContentTypeValues(contentTypeId, fieldId, values) {
-      await modifyValidationValuesForType('linkContentType', addValidationValues, contentTypeId, fieldId, values);
+      await modifyValidationValuesForType(['linkContentType'], addValidationValues, contentTypeId, fieldId, values);
     },
 
     /**
@@ -85,21 +118,21 @@ const getValidationHelpers = (migration, context) => {
      */
     async addInValues(contentTypeId, fieldId, values, options = {}) {
       const addValuesWithOptions = (existingValues, newValues = []) => addValues(existingValues, newValues, options);
-      await modifyValidationValuesForType('in', addValuesWithOptions, contentTypeId, fieldId, values);
+      await modifyValidationValuesForType(['in'], addValuesWithOptions, contentTypeId, fieldId, values);
     },
 
     /**
      * Remove the specified values from the list of allowed content type values
      */
     async removeLinkContentTypeValues(contentTypeId, fieldId, values) {
-      await modifyValidationValuesForType('linkContentType', removeValidationValues, contentTypeId, fieldId, values);
+      await modifyValidationValuesForType(['linkContentType'], removeValidationValues, contentTypeId, fieldId, values);
     },
 
     /**
      * Remove the specified values from the list of allowed values
      */
     async removeInValues(contentTypeId, fieldId, values) {
-      await modifyValidationValuesForType('in', removeValidationValues, contentTypeId, fieldId, values);
+      await modifyValidationValuesForType(['in'], removeValidationValues, contentTypeId, fieldId, values);
     },
 
     /**
@@ -108,7 +141,7 @@ const getValidationHelpers = (migration, context) => {
      */
     async modifyLinkContentTypeValues(contentTypeId, fieldId, valueMappingFunction) {
       const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
-      await modifyValidationValuesForType('linkContentType', uniqueMappingFunction, contentTypeId, fieldId, []);
+      await modifyValidationValuesForType(['linkContentType'], uniqueMappingFunction, contentTypeId, fieldId, []);
     },
 
     /**
@@ -117,7 +150,66 @@ const getValidationHelpers = (migration, context) => {
      */
     async modifyInValues(contentTypeId, fieldId, valueMappingFunction) {
       const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
-      await modifyValidationValuesForType('in', uniqueMappingFunction, contentTypeId, fieldId, []);
+      await modifyValidationValuesForType(['in'], uniqueMappingFunction, contentTypeId, fieldId, []);
+    },
+
+    richText: {
+      async addEnabledMarksValue(contentTypeId, fieldId, values, options) {
+        await modifyValidationValuesForType(['enabledMarks'], addValidationValues, contentTypeId, fieldId, values);
+      },
+      async removeEnabledMarksValue(contentTypeId, fieldId, values) {
+        await modifyValidationValuesForType(['enabledMarks'], removeValidationValues, contentTypeId, fieldId, values);
+      },
+      async modifyEnabledMarksValue(contentTypeId, fieldId, valueMappingFunction) {
+        const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
+        await modifyValidationValuesForType(['enabledMarks'], uniqueMappingFunction, contentTypeId, fieldId, []);
+      },
+
+      async addEnabledNodeTypeValue(contentTypeId, fieldId, values) {
+        await modifyValidationValuesForType(['enabledNodeTypes'], addValidationValues, contentTypeId, fieldId, values);
+      },
+      async removeEnabledNodeTypeValue(contentTypeId, fieldId, values) {
+        await modifyValidationValuesForType(
+          ['enabledNodeTypes'],
+          removeValidationValues,
+          contentTypeId,
+          fieldId,
+          values
+        );
+      },
+      async modifyEnabledNodeTypeValue(contentTypeId, fieldId, valueMappingFunction) {
+        const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
+        await modifyValidationValuesForType(['enabledNodeTypes'], uniqueMappingFunction, contentTypeId, fieldId, []);
+      },
+
+      async addNodeContentTypeValues(contentTypeId, fieldId, nodeType, values) {
+        await modifyValidationValuesForType(
+          ['nodes', nodeType, 'linkContentType'],
+          addValidationValues,
+          contentTypeId,
+          fieldId,
+          values
+        );
+      },
+      async removeNodeContentTypeValues(contentTypeId, fieldId, nodeType, values) {
+        await modifyValidationValuesForType(
+          ['nodes', nodeType, 'linkContentType'],
+          removeValidationValues,
+          contentTypeId,
+          fieldId,
+          values
+        );
+      },
+      async modifyNodeContentTypeValues(contentTypeId, fieldId, nodeType, valueMappingFunction) {
+        const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
+        await modifyValidationValuesForType(
+          ['nodes', nodeType, 'linkContentType'],
+          uniqueMappingFunction,
+          contentTypeId,
+          fieldId,
+          []
+        );
+      },
     },
   };
 };

--- a/lib/helpers/validation.js
+++ b/lib/helpers/validation.js
@@ -70,9 +70,7 @@ const getValidationHelpers = (migration, context) => {
   const modifyValidations = (validations = [], method, keyPaths, values) => {
     const [containerObject, validationKey] = ensureObjectPath(validations, keyPaths);
 
-    const resultList = method(containerObject[validationKey], values);
-
-    containerObject[validationKey] = resultList;
+    containerObject[validationKey] = method(containerObject[validationKey], values);
 
     return validations;
   };
@@ -154,21 +152,21 @@ const getValidationHelpers = (migration, context) => {
     },
 
     richText: {
-      async addEnabledMarksValue(contentTypeId, fieldId, values, options) {
+      async addEnabledMarksValues(contentTypeId, fieldId, values) {
         await modifyValidationValuesForType(['enabledMarks'], addValidationValues, contentTypeId, fieldId, values);
       },
-      async removeEnabledMarksValue(contentTypeId, fieldId, values) {
+      async removeEnabledMarksValues(contentTypeId, fieldId, values) {
         await modifyValidationValuesForType(['enabledMarks'], removeValidationValues, contentTypeId, fieldId, values);
       },
-      async modifyEnabledMarksValue(contentTypeId, fieldId, valueMappingFunction) {
+      async modifyEnabledMarksValues(contentTypeId, fieldId, valueMappingFunction) {
         const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
         await modifyValidationValuesForType(['enabledMarks'], uniqueMappingFunction, contentTypeId, fieldId, []);
       },
 
-      async addEnabledNodeTypeValue(contentTypeId, fieldId, values) {
+      async addEnabledNodeTypeValues(contentTypeId, fieldId, values) {
         await modifyValidationValuesForType(['enabledNodeTypes'], addValidationValues, contentTypeId, fieldId, values);
       },
-      async removeEnabledNodeTypeValue(contentTypeId, fieldId, values) {
+      async removeEnabledNodeTypeValues(contentTypeId, fieldId, values) {
         await modifyValidationValuesForType(
           ['enabledNodeTypes'],
           removeValidationValues,
@@ -177,7 +175,7 @@ const getValidationHelpers = (migration, context) => {
           values
         );
       },
-      async modifyEnabledNodeTypeValue(contentTypeId, fieldId, valueMappingFunction) {
+      async modifyEnabledNodeTypeValues(contentTypeId, fieldId, valueMappingFunction) {
         const uniqueMappingFunction = (values) => unique(valueMappingFunction(values));
         await modifyValidationValuesForType(['enabledNodeTypes'], uniqueMappingFunction, contentTypeId, fieldId, []);
       },

--- a/lib/helpers/validation.test.js
+++ b/lib/helpers/validation.test.js
@@ -6,7 +6,6 @@ describe('getValidationHelpers', () => {
       {
         id: 'selectWithOtherValidationProps',
         type: 'Text',
-        items: [],
         validations: [
           {
             foo: 'test',
@@ -20,7 +19,6 @@ describe('getValidationHelpers', () => {
       {
         id: 'select',
         type: 'Text',
-        items: [],
         validations: [
           {
             in: ['foo', 'bar', 'baz'],
@@ -37,9 +35,54 @@ describe('getValidationHelpers', () => {
         ],
       },
       {
+        id: 'string',
+        type: 'Text',
+      },
+      {
         id: 'string-array',
         type: 'Array',
         items: [],
+      },
+      {
+        id: 'richTextNoValidations',
+        type: 'RichText',
+      },
+      {
+        id: 'richTextFullValidations',
+        type: 'RichText',
+        validations: [
+          {
+            enabledMarks: ['bold', 'italic'],
+          },
+          {
+            enabledNodeTypes: [
+              'blockquote',
+              'embedded-entry-block',
+              'hyperlink',
+              'entry-hyperlink',
+              'embedded-entry-inline',
+            ],
+          },
+          {
+            nodes: {
+              'embedded-entry-block': [
+                {
+                  linkContentType: ['foo', 'baz'],
+                },
+              ],
+              'embedded-entry-inline': [
+                {
+                  linkContentType: ['foo'],
+                },
+              ],
+              'entry-hyperlink': [
+                {
+                  linkContentType: ['bar'],
+                },
+              ],
+            },
+          },
+        ],
       },
     ],
   });
@@ -95,6 +138,16 @@ describe('getValidationHelpers', () => {
       expect(resultValidation).toEqual([
         {
           in: ['bar', 'bat', 'baz', 'foo', 'test'],
+        },
+      ]);
+    });
+
+    it('should add values where none where defined', async () => {
+      const validations = getValidationHelpers(migration, context);
+      await validations.addInValues('some-content-type', 'string', 'foo');
+      expect(resultValidation).toEqual([
+        {
+          in: ['foo'],
         },
       ]);
     });
@@ -166,6 +219,154 @@ describe('getValidationHelpers', () => {
           linkContentType: ['foo', 'bar', 'test'],
         },
       ]);
+    });
+  });
+
+  describe('richText', () => {
+    describe('addEnabledMarksValue', () => {
+      it('should add values at the end', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.addEnabledMarksValue('some-content-type', 'richTextFullValidations', 'code');
+        expect(resultValidation).toContainEqual({
+          enabledMarks: ['bold', 'italic', 'code'],
+        });
+      });
+    });
+
+    describe('removeEnabledMarksValue', () => {
+      it('should remove values', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.removeEnabledMarksValue('some-content-type', 'richTextFullValidations', 'bold');
+        expect(resultValidation).toContainEqual({
+          enabledMarks: ['italic'],
+        });
+      });
+    });
+
+    describe('modifyEnabledMarksValue', () => {
+      it('should modify unique values with custom function', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.modifyEnabledMarksValue('some-content-type', 'richTextFullValidations', (values) => {
+          const result = values.slice(0, values.length - 1); // remove italic
+          result.push('code');
+          result.push('bold'); // should be removed since it exists
+          return result;
+        });
+        expect(resultValidation).toContainEqual({
+          enabledMarks: ['bold', 'code'],
+        });
+      });
+    });
+
+    describe('addEnabledNodeTypeValue', () => {
+      it('should add values at the end', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.addEnabledNodeTypeValue('some-content-type', 'richTextFullValidations', 'hr');
+        expect(resultValidation).toContainEqual({
+          enabledNodeTypes: [
+            'blockquote',
+            'embedded-entry-block',
+            'hyperlink',
+            'entry-hyperlink',
+            'embedded-entry-inline',
+            'hr',
+          ],
+        });
+      });
+    });
+
+    describe('removeEnabledNodeTypeValue', () => {
+      it('should remove values', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.removeEnabledNodeTypeValue(
+          'some-content-type',
+          'richTextFullValidations',
+          'blockquote'
+        );
+        expect(resultValidation).toContainEqual({
+          enabledNodeTypes: ['embedded-entry-block', 'hyperlink', 'entry-hyperlink', 'embedded-entry-inline'],
+        });
+      });
+    });
+
+    describe('modifyEnabledNodeTypeValue', () => {
+      it('should modify unique values with custom function', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.modifyEnabledNodeTypeValue(
+          'some-content-type',
+          'richTextFullValidations',
+          (values) => {
+            const result = values.slice(0, values.length - 1); // remove embedded-entry-inline
+            result.push('hr');
+            result.push('blockquote'); // should be removed since it exists
+            return result;
+          }
+        );
+        expect(resultValidation).toContainEqual({
+          enabledNodeTypes: [
+            'blockquote',
+            'embedded-entry-block',
+            'hyperlink',
+            'entry-hyperlink',
+            'hr',
+          ],
+        });
+      });
+    });
+
+    describe('addNodeContentTypeValues', () => {
+      it('should add values at the end', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.addNodeContentTypeValues(
+          'some-content-type',
+          'richTextFullValidations',
+          'embedded-entry-block',
+          'bar'
+        );
+        console.log('### ', resultValidation.find((v) => v.nodes))
+        expect(resultValidation.find((v) => v.nodes).nodes['embedded-entry-block']).toEqual([{
+          linkContentType: ['foo', 'baz', 'bar'],
+        }]);
+      });
+    });
+
+    describe('removeNodeContentTypeValues', () => {
+      it('should remove values', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.removeNodeContentTypeValues(
+          'some-content-type',
+          'richTextFullValidations',
+          'blockquote'
+        );
+        expect(resultValidation).toContainEqual({
+          enabledNodeTypes: ['embedded-entry-block', 'hyperlink', 'entry-hyperlink', 'embedded-entry-inline'],
+        });
+      });
+    });
+
+    describe('modifyNodeContentTypeValues', () => {
+      it('should modify unique values with custom function', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.modifyNodeContentTypeValues(
+          'some-content-type',
+          'richTextFullValidations',
+          (values) => {
+            const result = values.slice(0, values.length - 1); // remove embedded-entry-inline
+            result.push('hr');
+            result.push('blockquote'); // should be removed since it exists
+            return result;
+          }
+        );
+        expect(resultValidation).toContainEqual({
+          enabledNodeTypes: [
+            'blockquote',
+            'embedded-entry-block',
+            'hyperlink',
+            'entry-hyperlink',
+            'hr',
+          ],
+        });
+      });
     });
   });
 });

--- a/lib/helpers/validation.test.js
+++ b/lib/helpers/validation.test.js
@@ -75,11 +75,6 @@ describe('getValidationHelpers', () => {
                   linkContentType: ['foo'],
                 },
               ],
-              'entry-hyperlink': [
-                {
-                  linkContentType: ['bar'],
-                },
-              ],
             },
           },
         ],
@@ -226,7 +221,7 @@ describe('getValidationHelpers', () => {
     describe('addEnabledMarksValue', () => {
       it('should add values at the end', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.addEnabledMarksValue('some-content-type', 'richTextFullValidations', 'code');
+        await validations.richText.addEnabledMarksValues('some-content-type', 'richTextFullValidations', 'code');
         expect(resultValidation).toContainEqual({
           enabledMarks: ['bold', 'italic', 'code'],
         });
@@ -236,7 +231,7 @@ describe('getValidationHelpers', () => {
     describe('removeEnabledMarksValue', () => {
       it('should remove values', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.removeEnabledMarksValue('some-content-type', 'richTextFullValidations', 'bold');
+        await validations.richText.removeEnabledMarksValues('some-content-type', 'richTextFullValidations', 'bold');
         expect(resultValidation).toContainEqual({
           enabledMarks: ['italic'],
         });
@@ -246,12 +241,16 @@ describe('getValidationHelpers', () => {
     describe('modifyEnabledMarksValue', () => {
       it('should modify unique values with custom function', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.modifyEnabledMarksValue('some-content-type', 'richTextFullValidations', (values) => {
-          const result = values.slice(0, values.length - 1); // remove italic
-          result.push('code');
-          result.push('bold'); // should be removed since it exists
-          return result;
-        });
+        await validations.richText.modifyEnabledMarksValues(
+          'some-content-type',
+          'richTextFullValidations',
+          (values) => {
+            const result = values.slice(0, values.length - 1); // remove italic
+            result.push('code');
+            result.push('bold'); // should be removed since it exists
+            return result;
+          }
+        );
         expect(resultValidation).toContainEqual({
           enabledMarks: ['bold', 'code'],
         });
@@ -261,7 +260,7 @@ describe('getValidationHelpers', () => {
     describe('addEnabledNodeTypeValue', () => {
       it('should add values at the end', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.addEnabledNodeTypeValue('some-content-type', 'richTextFullValidations', 'hr');
+        await validations.richText.addEnabledNodeTypeValues('some-content-type', 'richTextFullValidations', 'hr');
         expect(resultValidation).toContainEqual({
           enabledNodeTypes: [
             'blockquote',
@@ -278,7 +277,7 @@ describe('getValidationHelpers', () => {
     describe('removeEnabledNodeTypeValue', () => {
       it('should remove values', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.removeEnabledNodeTypeValue(
+        await validations.richText.removeEnabledNodeTypeValues(
           'some-content-type',
           'richTextFullValidations',
           'blockquote'
@@ -292,7 +291,7 @@ describe('getValidationHelpers', () => {
     describe('modifyEnabledNodeTypeValue', () => {
       it('should modify unique values with custom function', async () => {
         const validations = getValidationHelpers(migration, context);
-        await validations.richText.modifyEnabledNodeTypeValue(
+        await validations.richText.modifyEnabledNodeTypeValues(
           'some-content-type',
           'richTextFullValidations',
           (values) => {
@@ -303,13 +302,7 @@ describe('getValidationHelpers', () => {
           }
         );
         expect(resultValidation).toContainEqual({
-          enabledNodeTypes: [
-            'blockquote',
-            'embedded-entry-block',
-            'hyperlink',
-            'entry-hyperlink',
-            'hr',
-          ],
+          enabledNodeTypes: ['blockquote', 'embedded-entry-block', 'hyperlink', 'entry-hyperlink', 'hr'],
         });
       });
     });
@@ -323,10 +316,26 @@ describe('getValidationHelpers', () => {
           'embedded-entry-block',
           'bar'
         );
-        console.log('### ', resultValidation.find((v) => v.nodes))
-        expect(resultValidation.find((v) => v.nodes).nodes['embedded-entry-block']).toEqual([{
-          linkContentType: ['foo', 'baz', 'bar'],
-        }]);
+        expect(resultValidation.find((v) => v.nodes).nodes['embedded-entry-block']).toEqual([
+          {
+            linkContentType: ['foo', 'baz', 'bar'],
+          },
+        ]);
+      });
+
+      it('should add complete entry if not existing', async () => {
+        const validations = getValidationHelpers(migration, context);
+        await validations.richText.addNodeContentTypeValues(
+          'some-content-type',
+          'richTextFullValidations',
+          'entry-hyperlink',
+          'bar'
+        );
+        expect(resultValidation.find((v) => v.nodes).nodes['entry-hyperlink']).toEqual([
+          {
+            linkContentType: ['bar'],
+          },
+        ]);
       });
     });
 
@@ -336,11 +345,14 @@ describe('getValidationHelpers', () => {
         await validations.richText.removeNodeContentTypeValues(
           'some-content-type',
           'richTextFullValidations',
-          'blockquote'
+          'embedded-entry-block',
+          'foo'
         );
-        expect(resultValidation).toContainEqual({
-          enabledNodeTypes: ['embedded-entry-block', 'hyperlink', 'entry-hyperlink', 'embedded-entry-inline'],
-        });
+        expect(resultValidation.find((v) => v.nodes).nodes['embedded-entry-block']).toEqual([
+          {
+            linkContentType: ['baz'],
+          },
+        ]);
       });
     });
 
@@ -350,22 +362,19 @@ describe('getValidationHelpers', () => {
         await validations.richText.modifyNodeContentTypeValues(
           'some-content-type',
           'richTextFullValidations',
+          'embedded-entry-block',
           (values) => {
-            const result = values.slice(0, values.length - 1); // remove embedded-entry-inline
-            result.push('hr');
-            result.push('blockquote'); // should be removed since it exists
+            const result = values.slice(0, values.length - 1); // remove foo
+            result.push('bar');
+            result.push('baz'); // should be removed since it exists
             return result;
           }
         );
-        expect(resultValidation).toContainEqual({
-          enabledNodeTypes: [
-            'blockquote',
-            'embedded-entry-block',
-            'hyperlink',
-            'entry-hyperlink',
-            'hr',
-          ],
-        });
+        expect(resultValidation.find((v) => v.nodes).nodes['embedded-entry-block']).toEqual([
+          {
+            linkContentType: ['foo', 'bar', 'baz'],
+          },
+        ]);
       });
     });
   });


### PR DESCRIPTION
Similar to the existing validation helpers that enable modification of validation rules without needing to know the actual rules some helpers where added for rich text fields.

To support the special structure for the linkContentTypes some refactoring of the internal generic modification functions where needed.

Currently this code was just tested with the unit tests.