### PR TITLE
fix: filename version matching

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -358,11 +358,11 @@ const getLatestVersion = async (config) => {
 
 const getVersionFromFile = (file) => {
   const name = path.basename(file);
-  const versionMatch = name.match(/^\d+/);
+  const versionMatch = /^\d+/.exec(name);
   if (!versionMatch) {
     return undefined;
   }
-  return parseInt(versionMatch[0], 10);
+  return Number.parseInt(versionMatch[0], 10);
 };
 
 /**

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -358,8 +358,11 @@ const getLatestVersion = async (config) => {
 
 const getVersionFromFile = (file) => {
   const name = path.basename(file);
-  const [, num] = /^(\d+)-/.exec(name);
-  return parseInt(num, 10);
+  const versionMatch = name.match(/^\d+/);
+  if (!versionMatch) {
+    return undefined;
+  }
+  return parseInt(versionMatch[0], 10);
 };
 
 /**
@@ -372,7 +375,7 @@ const getNewMigrations = async (config) => {
   const migrations = (await globby([`${directory}/*.js`, `${directory}/*.cjs`])).sort((a, b) => {
     const numA = getVersionFromFile(a);
     const numB = getVersionFromFile(b);
-    return numA - numB;
+    return (numA || 0) - (numB || 0);
   });
 
   if (storage === STORAGE_CONTENT) {
@@ -380,7 +383,7 @@ const getNewMigrations = async (config) => {
       const versions = await getMigrationVersions(config);
       const result = migrations.filter((file) => {
         const num = getVersionFromFile(file);
-        return !(versions || []).includes(num);
+        return !!num && !(versions || []).includes(num);
       });
 
       return result;
@@ -420,3 +423,4 @@ module.exports.getMigrationVersionFromTag = getMigrationVersionFromTag;
 module.exports.getLatestVersion = getLatestVersion;
 module.exports.storeMigration = storeMigration;
 module.exports.getNewMigrations = getNewMigrations;
+module.exports.getVersionFromFile = getVersionFromFile;

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -112,14 +112,14 @@ const addMigrationEntry = async (data, config) => {
 
   let entry;
   try {
-    entry = await client.getEntry(version);
+    entry = await client.getEntry(`${version}`);
   } catch {}
 
   if (!entry) {
-    entry = await client.createEntryWithId(migrationContentTypeId, version, {
+    entry = await client.createEntryWithId(migrationContentTypeId, `${version}`, {
       fields: {
         version: {
-          [defaultLocale]: version,
+          [defaultLocale]: `${version}`,
         },
         name: {
           [defaultLocale]: name,

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -12,7 +12,7 @@ const { getEnvironment, getOrganizationId } = require('./contentful');
 
 const { confirm, STATE_SUCCESS, STATE_FAILURE } = require('./config');
 
-const { storeMigration, getNewMigrations } = require('./backend');
+const { storeMigration, getNewMigrations, getVersionFromFile } = require('./backend');
 
 const migrationHeader = stripIndent`/* eslint-env node */
   const { withHelpers } = require('@jungvonmatt/contentful-migrations');
@@ -143,11 +143,11 @@ const executeMigration = async (file, config) => {
   const environmentId = client.sys.id;
   const organizationId = await getOrganizationId(config);
   const name = path.basename(file);
-  const versionMatch = name.match(/^\d+/);
-  if (!versionMatch) {
-    throw new Error(`Invalid migration file name ${name}. Must start with a timestamp.`);
+  const version = getVersionFromFile(file);
+  if (!version) {
+    console.error(`Invalid migration file name "${name}". Must start with a timestamp.`);
+    process.exit(1);
   }
-  const version = versionMatch[0];
 
   const options = {
     filePath: path.resolve(file),

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -143,7 +143,11 @@ const executeMigration = async (file, config) => {
   const environmentId = client.sys.id;
   const organizationId = await getOrganizationId(config);
   const name = path.basename(file);
-  const [, version] = /^(\d+)-/.exec(name);
+  const versionMatch = name.match(/^\d+/);
+  if (!versionMatch) {
+    throw new Error(`Invalid migration file name ${name}. Must start with a timestamp.`);
+  }
+  const version = versionMatch[0];
 
   const options = {
     filePath: path.resolve(file),


### PR DESCRIPTION
Executing a migration that did not have a dash after the version number resulted in an error, that was not even logged.

Example file name: `1771498088693_some_migration`

The regexp matching for the version number was improved to simply grab all the numbers at the start, no matter what comes afterward.
If no version could be found a log message is written in the console.

We do not just throw an error, since the execute command is run with log=true, which would not log any thrown error.
Also because of this we have a second place where we use process.exit(1).
It feels like we should improve the error handling in general here, but maybe not in this PR.