### PR TITLE
Feature: Allow naming migration files via `generate --name`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -155,6 +155,7 @@ program
   .option('--host <host>', 'Management API host')
   .option('--config <path/to/config>', 'Config file path (disables auto detect)')
   .option('--cwd <directory>', 'Working directory. Defaults to process.cwd()')
+  .option('-n, --name <name>', 'Set a name for the migration')
   .description('Generate a new Contentful migration')
   .action(
     actionRunner(async (cmd) => {
@@ -164,7 +165,7 @@ program
         'environmentId',
         'directory',
       ]);
-      await createMigration(config);
+      await createMigration({ ...config, name: cmd.name });
     })
   );
 

--- a/lib/helpers/slugify.js
+++ b/lib/helpers/slugify.js
@@ -1,0 +1,9 @@
+const slugify = (text) =>
+  text
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+module.exports = { slugify };

--- a/lib/helpers/slugify.js
+++ b/lib/helpers/slugify.js
@@ -1,10 +1,11 @@
 const slugify = (text) =>
   text
     .toString()
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '');
+    .replace(/^-/, '')
+    .replace(/-$/, '');
 
 module.exports = { slugify };

--- a/lib/helpers/slugify.js
+++ b/lib/helpers/slugify.js
@@ -4,6 +4,7 @@ const slugify = (text) =>
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
 
 module.exports = { slugify };

--- a/lib/helpers/slugify.test.js
+++ b/lib/helpers/slugify.test.js
@@ -38,4 +38,17 @@ describe('slugify', () => {
   it('handles colons and mixed punctuation', () => {
     expect(slugify('Fix: content model!')).toBe('fix-content-model');
   });
+
+  it('handles leading and trailing hyphens', () => {
+    expect(slugify('--hello--')).toBe('hello');
+  });
+
+  it('handles underscores', () => {
+    expect(slugify('_create_user')).toBe('create-user');
+  });
+
+  it('handles camel case', () => {
+    expect(slugify('pArticle')).toBe('p-article');
+    expect(slugify('Create pArticle ContentType')).toBe('create-p-article-content-type');
+  });
 });

--- a/lib/helpers/slugify.test.js
+++ b/lib/helpers/slugify.test.js
@@ -1,0 +1,41 @@
+const { slugify } = require('./slugify');
+
+describe('slugify', () => {
+  it('converts spaces to hyphens and lowercases', () => {
+    expect(slugify('Add this new feature')).toBe('add-this-new-feature');
+  });
+
+  it('removes special characters', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(slugify('  spaced  out  ')).toBe('spaced-out');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugify('--hello--')).toBe('hello');
+  });
+
+  it('collapses consecutive special characters into a single hyphen', () => {
+    expect(slugify('foo---bar   baz')).toBe('foo-bar-baz');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(slugify('   ')).toBe('');
+  });
+
+  it('returns empty string for invalid string input', () => {
+    expect(slugify('')).toBe('');
+    expect(slugify('-')).toBe('');
+    expect(slugify('%/&((§/')).toBe('');
+  });
+
+  it('preserves numbers', () => {
+    expect(slugify('Version 2 update')).toBe('version-2-update');
+  });
+
+  it('handles colons and mixed punctuation', () => {
+    expect(slugify('Fix: content model!')).toBe('fix-content-model');
+  });
+});

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -13,6 +13,7 @@ const { getEnvironment, getOrganizationId } = require('./contentful');
 const { confirm, STATE_SUCCESS, STATE_FAILURE } = require('./config');
 
 const { storeMigration, getNewMigrations, getVersionFromFile } = require('./backend');
+const { slugify } = require('./helpers/slugify');
 
 const migrationHeader = stripIndent`/* eslint-env node */
   const { withHelpers } = require('@jungvonmatt/contentful-migrations');
@@ -40,11 +41,14 @@ const createMigration = async (config) => {
     console.log(err);
   }
 
-  const { directory } = config || {};
+  const { directory, name } = config || {};
   const timestamp = Date.now();
-  const filename = path.join(directory, `${timestamp}-migration.${module ? 'cjs' : 'js'}`);
+  const hasName = name && slugify(name);
+  const slug = hasName || 'migration';
+  const filename = path.join(directory, `${timestamp}-${slug}.${module ? 'cjs' : 'js'}`);
+  const comment = hasName ? `// ${name}` : '// Add your migration code here';
   const content = stripIndent`${migrationHeader}
-    // Add your migration code here
+    ${comment}
   })`;
 
   await fs.outputFile(filename, await format(filename, content, config));


### PR DESCRIPTION
When generating a new migration, the filename always defaults to `{timestamp}-migration.js`, requiring a manual rename to something meaningful. This is especially annoying for automated workflows (e.g. AI coding agents).

This PR adds an optional `-n, --name` flag to `generate` that sluggifies the provided name into the filename and places it as a comment inside the generated file. Fully backward-compatible -- omitting the flag preserves the existing behavior.

### Changes

- Added `-n, --name <name>` option to the `generate` CLI command
- Changed `createMigration` to use a slugified name in the filename and as in-file comment
- Added `lib/helpers/slugify.js` utility (zero dependencies, 7 LOC)
- Added `lib/helpers/slugify.test.js` with 9 test cases covering edge cases

### How to test

```bash
# Existing behavior unchanged
npx migrations generate
# -> migrations/1710000000000-migration.js

# With name
npx migrations generate -n "Add hero section"
# -> migrations/1710000000000-add-hero-section.js
# File contains: // Add hero section

# Edge case: special-chars-only name falls back gracefully
npx migrations generate -n "---"
# -> migrations/1710000000000-migration.js
```