### PR TITLE
Feature: Log migrations if verbose

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -198,7 +198,12 @@ const runMigrations = async (config) => {
     throw error;
   }
   console.log(`Found ${pc.green(migrations.length)} unexecuted migrations in environment ${pc.green(environmentId)}`);
-
+  if (config?.verbose) {
+    for (const migration of migrations) {
+      console.log(`  ${pc.green(migration)}`);
+    }
+    console.log();
+  }
   const proceed = migrations.length === 0 || (await confirm(config));
   if (!proceed) {
     return;


### PR DESCRIPTION
Will now log the migration files that are not executed when running `migrations migrate -v`