### PR TITLE
fix: use legacy client for contentful-management v12

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -76,7 +76,10 @@ const getClient = async (options) => {
   }
 
   if (params.accessToken) {
-    client = await contentful.createClient(params);
+    // contentful-management v12 defaults to the "plain" client, which lacks the
+    // nested helpers this package relies on (client.getSpace, space.getEnvironment,
+    // apiKey.update, ...). Explicitly request the legacy/nested client. See #88.
+    client = await contentful.createClient(params, { type: "legacy" });
     return client;
   }
 

--- a/lib/contentful.test.js
+++ b/lib/contentful.test.js
@@ -74,10 +74,13 @@ describe('contentful helpers', () => {
     });
 
     expect(createClient).toHaveBeenCalledTimes(1);
-    expect(createClient).toHaveBeenCalledWith({
-      accessToken: 'token',
-      host: 'api.eu.contentful.com',
-    });
+    expect(createClient).toHaveBeenCalledWith(
+      {
+        accessToken: 'token',
+        host: 'api.eu.contentful.com',
+      },
+      { type: 'legacy' },
+    );
     expect(second).toBe(first);
   });
 


### PR DESCRIPTION
contentful-management v12 defaults createClient() to the plain client, which lacks the nested helpers this package relies on (client.getSpace, space.getEnvironment, apiKey.update, ...). Explicitly request the legacy/nested client to restore the v11 behavior.

Fixes #88